### PR TITLE
Add support for ECS member tenants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folio_data_import"
-version = "0.2.0"
+version = "0.2.1"
 description = "A python module to interact with the data importing capabilities of the open-source FOLIO ILS"
 authors = ["Brooks Travis <brooks.travis@gmail.com>"]
 license = "MIT"

--- a/src/folio_data_import/MARCDataImport.py
+++ b/src/folio_data_import/MARCDataImport.py
@@ -436,6 +436,12 @@ async def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--gateway_url", type=str, help="The FOLIO API Gateway URL")
     parser.add_argument("--tenant_id", type=str, help="The FOLIO tenant ID")
+    parser.add_argument(
+        "--member_tenant_id",
+        type=str,
+        help="The FOLIO ECS member tenant ID (if applicable)",
+        default="",
+    )
     parser.add_argument("--username", type=str, help="The FOLIO username")
     parser.add_argument("--password", type=str, help="The FOLIO password", default="")
     parser.add_argument(
@@ -480,6 +486,11 @@ async def main() -> None:
     folio_client = folioclient.FolioClient(
         args.gateway_url, args.tenant_id, args.username, args.password
     )
+
+    # Set the member tenant id if provided to support FOLIO ECS multi-tenant environments
+    if args.member_tenant_id:
+        folio_client.okapi_headers["x-okapi-tenant"] = args.member_tenant_id
+
     if not args.import_profile_name:
         import_profiles = folio_client.folio_get(
             "/data-import-profiles/jobProfiles",

--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -630,6 +630,11 @@ async def main() -> None:
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("--tenant_id", help="The tenant id")
+    parser.add_argument(
+        "--member_tenant_id",
+        help="The FOLIO ECS member tenant id (if applicable)",
+        default="",
+    )
     parser.add_argument("--library_name", help="The name of the library")
     parser.add_argument("--username", help="The FOLIO username")
     parser.add_argument("--okapi_url", help="The Okapi URL")
@@ -672,8 +677,15 @@ async def main() -> None:
         args.username,
         args.folio_password
         or os.environ.get("FOLIO_PASS", "")
-        or getpass.getpass("Enter your FOLIO password: "),
+        or getpass.getpass(
+            "Enter your FOLIO password: ",
+        ),
     )
+
+    # Set the member tenant id if provided to support FOLIO ECS multi-tenant environments
+    if args.member_tenant_id:
+        folio_client.okapi_headers["x-okapi-tenant"] = args.member_tenant_id
+
     user_file_path = Path(args.user_file_path)
     log_file_path = (
         user_file_path.parent.parent


### PR DESCRIPTION
Add support for ECS member tenants when running via command-line via optional --member_tenant_id argument.