### PR TITLE
Improve error reporting for folio_client instantiation failures

### DIFF
--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -920,13 +920,10 @@ async def main() -> None:
             response_content = str(e.response.content)
 
         error_message = (
-            f"Failed to initialize FOLIO client: HTTP {e.response.status_code} {e.response.reason_phrase}\n"
-            f"URL: {e.request.url}\n"
+            f"{e} \n" 
             f"Response content: {response_content}\n"
-            f"More details: https://httpstatuses.com/{e.response.status_code}"
         )
-        print(error_message)
-        raise Exception(error_message) from e
+        raise Exception(error_message) from None
 
     except httpx.HTTPError as e:
         print(f"Error initializing FOLIO client: {e}")

--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -916,6 +916,25 @@ async def main() -> None:
         response_content = ""
         try:
             response_content = e.response.content.decode('utf-8').strip()
+
+            # Try parsing as JSON and extracting specific fields
+            try:
+                response_json = json.loads(response_content)
+                if "errors" in response_json and isinstance(response_json["errors"], list):
+                    error_details = []
+                    for error in response_json["errors"]:
+                        message = error.get("message", "No message provided")
+                        error_type = error.get("type", "No type provided")
+                        code = error.get("code", "No code provided")
+                        error_details.append(f"Type: {error_type}, Code: {code}, Message: {message}")
+
+                    response_content = "\n".join(error_details)
+                else:
+                    response_content = json.dumps(response_json, indent=2)  # Fallback to formatted JSON
+
+            except json.JSONDecodeError:
+                pass  # Keep response_content as is if not valid JSON
+
         except UnicodeDecodeError:
             response_content = str(e.response.content)
 


### PR DESCRIPTION
This pull request addresses the issue tracked in my fork: [GIL-GALILEO/folio_data_import#3](https://github.com/GIL-GALILEO/folio_data_import/issues/3)


Hi Brooks!  

During initial testing, I found it challenging to determine which parameters were incorrect when the folio_client instantiation failed.

Upon further investigation using a debugger, I found that the FOLIO API often returns more specific error messages, which are captured in `e.response.content` by httpx. 

For example, the API may return the following error messages:

```
{
  "errors" : [ {
    "message" : "Password does not match",
    "type" : "error",
    "code" : "password.incorrect",
    "parameters" : [ {
      "key" : "username",
      "value" : "user_import"
    } ]
  } ]
}

{
  "errors" : [ {
    "message" : "Error verifying user existence: No user found by username user_imports",
    "type" : "error",
    "code" : "username.incorrect",
    "parameters" : [ {
      "key" : "username",
      "value" : "user_imports"
    } ]
  } ]
}

No such Tenant cs000000022
```
Here's an example of the current traceback when supplying an incorrect password:

```
Traceback (most recent call last):
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/.venv/bin/folio-user-import", line 6, in <module>
    sys.exit(sync_main())
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/src/folio_data_import/UserImport.py", line 964, in sync_main
    asyncio.run(main())
  File "/Users/seanpurcell/.pyenv/versions/3.10.14/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/seanpurcell/.pyenv/versions/3.10.14/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/src/folio_data_import/UserImport.py", line 906, in main
    folio_client = folioclient.FolioClient(
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/.venv/lib/python3.10/site-packages/folioclient/FolioClient.py", line 59, in __init__
    self.login()
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/.venv/lib/python3.10/site-packages/folioclient/decorators.py", line 28, in wrapper
    return func(*args, **kwargs)
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/.venv/lib/python3.10/site-packages/folioclient/FolioClient.py", line 355, in login
    req.raise_for_status()
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/.venv/lib/python3.10/site-packages/httpx/_models.py", line 763, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '422 Unprocessable Entity' for url 'https://okapi-gil.folio.ebsco.com/authn/login-with-expiry'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422


Process finished with exit code 1
```

And here's an example of the new error traceback:

```

Traceback (most recent call last):
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/.venv/bin/folio-user-import", line 6, in <module>
    sys.exit(sync_main())
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/src/folio_data_import/UserImport.py", line 1002, in sync_main
    asyncio.run(main())
  File "/Users/seanpurcell/.pyenv/versions/3.10.14/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/seanpurcell/.pyenv/versions/3.10.14/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/seanpurcell/PycharmProjects/folio_data_import/src/folio_data_import/UserImport.py", line 945, in main
    raise Exception(error_message) from None
Exception: Client error '422 Unprocessable Entity' for url 'https://okapi-gil.folio.ebsco.com/authn/login-with-expiry'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422 
Response content: Type: error, Code: password.incorrect, Message: Password does not match


Process finished with exit code 1
``` 

