### PR TITLE
Improve timeout handling and overall logging behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Unlike mod-user-import, this importer does not require `externalSystemId` as the
 
 #### Preferred Contact Type Mapping
 
-Another point of departure from the behavior of `mod-user-import` is the handling of `preferredContactTypeId`. This importer will accept either the `"001", "002", "003"...` values stored by the FOLIO, or the human-friendly strings used by `mod-user-import` (`"mail", "email", "text", "phone", "mobile"`). It will also __*set a customizable default for all users that do not otherwise have a valid value specified*__ (using `--default_preferred_contact_type`), unless a (valid) value is already present in the user record being updated.
+Another point of departure from the behavior of `mod-user-import` is the handling of `preferredContactTypeId`. This importer will accept either the `"001", "002", "003"...` values stored by FOLIO, or the human-friendly strings used by `mod-user-import` (`"mail", "email", "text", "phone", "mobile"`). It will also __*set a customizable default for all users that do not otherwise have a valid value specified*__ (using `--default_preferred_contact_type`), unless a (valid) value is already present in the user record being updated.
 
 #### Field Protection (*experimental*)
 
-This script offers a rudimentary field protection implementation using custom fields. To enable this functionality, create a text custom field that has the field name `protectedFields`. In this field, you ca specify a comma-separated list of User schema field names, using dot-notation for nested fields. This protection should support all standard fields except addresses within `personal.addresses`. If you include `personal.addresses` in a user record, any existing addresses will be replaced by the new values.
+This script offers a rudimentary field protection implementation using custom fields. To enable this functionality, create a text custom field that has the field name `protectedFields`. In this field, you can specify a comma-separated list of User schema field names, using dot-notation for nested fields. This protection should support all standard fields except addresses within `personal.addresses`. If you include `personal.addresses` in a user record, any existing addresses will be replaced by the new values.
 
 ##### Example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folio_data_import"
-version = "0.2.8rc7"
+version = "0.2.8rc8"
 description = "A python module to interact with the data importing capabilities of the open-source FOLIO ILS"
 authors = ["Brooks Travis <brooks.travis@gmail.com>"]
 license = "MIT"

--- a/src/folio_data_import/MARCDataImport.py
+++ b/src/folio_data_import/MARCDataImport.py
@@ -3,6 +3,7 @@ import asyncio
 import glob
 import importlib
 import io
+import logging
 import os
 import sys
 from typing import List
@@ -21,7 +22,6 @@ import pymarc
 import tabulate
 from humps import decamelize
 from tqdm import tqdm
-from zmq import has
 
 
 try:
@@ -37,6 +37,7 @@ REPORT_SUMMARY_ORDERING = {"created": 0, "updated": 1, "discarded": 2, "error": 
 RETRY_TIMEOUT_START = 1
 RETRY_TIMEOUT_RETRY_FACTOR = 2
 
+logger = logging.getLogger(__name__)
 class MARCImportJob:
     """
     Class to manage importing MARC data (Bib, Authority) into FOLIO using the Change Manager
@@ -115,9 +116,9 @@ class MARCImportJob:
             "wb+",
         ) as failed_batches:
             self.bad_records_file = bad_marc_file
-            print(f"Writing bad records to {self.bad_records_file.name}")
+            logger.info(f"Writing bad records to {self.bad_records_file.name}")
             self.failed_batches_file = failed_batches
-            print(f"Writing failed batches to {self.failed_batches_file.name}")
+            logger.info(f"Writing failed batches to {self.failed_batches_file.name}")
             self.http_client = http_client
             if self.consolidate_files:
                 self.current_file = self.import_files
@@ -138,16 +139,16 @@ class MARCImportJob:
         Returns:
             None
         """
-        self.bad_records_file.seek(0)
-        if not self.bad_records_file.read(1):
-            os.remove(self.bad_records_file.name)
-            print("No bad records found. Removing bad records file.")
-        self.failed_batches_file.seek(0)
-        if not self.failed_batches_file.read(1):
-            os.remove(self.failed_batches_file.name)
-            print("No failed batches. Removing failed batches file.")
-        print("Import complete.")
-        print(f"Total records imported: {self.total_records_sent}")
+        with open(self.bad_records_file.name, "rb") as bad_records:
+            if not bad_records.read(1):
+                os.remove(bad_records.name)
+                logger.info("No bad records found. Removing bad records file.")
+        with open(self.failed_batches_file.name, "rb") as failed_batches:
+            if not failed_batches.read(1):
+                os.remove(failed_batches.name)
+                logger.info("No failed batches. Removing failed batches file.")
+        logger.info("Import complete.")
+        logger.info(f"Total records imported: {self.total_records_sent}")
 
     async def get_job_status(self) -> None:
         """
@@ -215,7 +216,7 @@ class MARCImportJob:
         try:
             create_job.raise_for_status()
         except httpx.HTTPError as e:
-            print(
+            logger.error(
                 "Error creating job: "
                 + str(e)
                 + "\n"
@@ -262,7 +263,7 @@ class MARCImportJob:
         try:
             set_job_profile.raise_for_status()
         except httpx.HTTPError as e:
-            print(
+            logger.error(
                 "Error creating job: "
                 + str(e)
                 + "\n"
@@ -318,7 +319,7 @@ class MARCImportJob:
                 self.record_batch = []
                 self.pbar_sent.update(len(batch_payload["initialRecords"]))
             else:
-                print("Error posting batch: " + str(e))
+                logger.error("Error posting batch: " + str(e))
                 for record in self.record_batch:
                     self.failed_batches_file.write(record)
                     self.error_records += len(self.record_batch)
@@ -384,18 +385,18 @@ class MARCImportJob:
                 module = importlib.import_module(module_path)
                 func = getattr(module, func_name)
             except (ImportError, AttributeError) as e:
-                print(f"Error importing preprocessing function {func_or_path}: {e}. Skipping preprocessing.")
+                logger.error(f"Error importing preprocessing function {func_or_path}: {e}. Skipping preprocessing.")
                 return record
         elif callable(func_or_path):
             func = func_or_path
         else:
-            print(f"Invalid preprocessing function: {func_or_path}. Skipping preprocessing.")
+            logger.warning(f"Invalid preprocessing function: {func_or_path}. Skipping preprocessing.")
             return record
 
         try:
             return func(record)
         except Exception as e:
-            print(f"Error applying preprocessing function: {e}. Skipping preprocessing.")
+            logger.error(f"Error applying preprocessing function: {e}. Skipping preprocessing.")
             return record
 
     async def create_batch_payload(self, counter, total_records, is_last) -> dict:
@@ -484,17 +485,17 @@ class MARCImportJob:
                     columns = columns[:1] + [
                         " ".join(decamelize(x).split("_")[:-1]) for x in columns[1:]
                     ]
-                    print(
+                    logger.info(
                         f"Results for {'file' if len(self.current_file) == 1 else 'files'}: "
                         f"{', '.join([os.path.basename(x.name) for x in self.current_file])}"
                     )
-                    print(
+                    logger.info("\n" +
                         tabulate.tabulate(
                             table_data, headers=columns, tablefmt="fancy_grid"
                         ),
                     )
                 else:
-                    print(f"No job summary available for job {self.job_id}.")
+                    logger.error(f"No job summary available for job {self.job_id}.")
             self.last_current = 0
             self.finished = False
 
@@ -541,6 +542,23 @@ async def main() -> None:
     This function parses command line arguments, initializes the FolioClient,
     and runs the MARCImportJob.
     """
+
+    # Set up logging
+    file_handler = logging.FileHandler('folio_data_import_{}.log'.format(dt.now().strftime('%Y%m%d%H%M%S')))
+    file_handler.setLevel(logging.INFO)
+    file_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    file_handler.setFormatter(file_formatter)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(message)s',
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            file_handler
+        ]
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--gateway_url", type=str, help="The FOLIO API Gateway URL")
     parser.add_argument("--tenant_id", type=str, help="The FOLIO tenant ID")
@@ -621,10 +639,10 @@ async def main() -> None:
     marc_files.sort()
 
     if len(marc_files) == 0:
-        print(f"No files found matching {args.marc_file_path}. Exiting.")
+        logger.critical(f"No files found matching {args.marc_file_path}. Exiting.")
         sys.exit(1)
     else:
-        print(marc_files)
+        logger.info(marc_files)
 
     if not args.import_profile_name:
         import_profiles = folio_client.folio_get(
@@ -659,7 +677,7 @@ async def main() -> None:
             let_summary_fail=bool(args.let_summary_fail),
         ).do_work()
     except Exception as e:
-        print("Error importing files: " + str(e))
+        logger.error("Error importing files: " + str(e))
         raise
 
 

--- a/src/folio_data_import/marc_preprocessors/__init__.py
+++ b/src/folio_data_import/marc_preprocessors/__init__.py
@@ -1,1 +1,1 @@
-from ._preprocessors import prepend_ppn_prefix_001, strip_999_ff_fields
+from ._preprocessors import *

--- a/src/folio_data_import/marc_preprocessors/_preprocessors.py
+++ b/src/folio_data_import/marc_preprocessors/_preprocessors.py
@@ -106,6 +106,8 @@ def clean_empty_fields(record: pymarc.Record) -> pymarc.Record:
     MAPPED_FIELDS = {
         "010": ["a", "z"],
         "020": ["a", "y", "z"],
+        "035": ["a", "z"],
+        "040": ["a", "b", "c", "d", "e", "f", "g", "h", "k", "m", "n", "p", "r", "s"],
         "050": ["a", "b"],
         "082": ["a", "b"],
         "100": ["a", "b", "c", "d", "q"],
@@ -128,6 +130,8 @@ def clean_empty_fields(record: pymarc.Record) -> pymarc.Record:
             "y",
             "z",
         ],
+        "180": ["x", "y", "z"],
+        "210": ["a", "c"],
         "240": ["a", "f", "k", "l", "m", "n", "o", "p", "r", "s", "t", "x", "y", "z"],
         "245": ["a", "b", "c", "f", "g", "h", "k", "n", "p", "s"],
         "246": ["a", "f", "g", "n", "p", "s"],

--- a/src/folio_data_import/marc_preprocessors/_preprocessors.py
+++ b/src/folio_data_import/marc_preprocessors/_preprocessors.py
@@ -1,7 +1,7 @@
 import pymarc
 import logging
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("folio_data_import.MARCDataImport")
 
 
 def prepend_prefix_001(record: pymarc.Record, prefix: str) -> pymarc.Record:
@@ -15,8 +15,9 @@ def prepend_prefix_001(record: pymarc.Record, prefix: str) -> pymarc.Record:
     Returns:
         pymarc.Record: The preprocessed MARC record.
     """
-    record['001'].data = f'({prefix})' + record['001'].data
+    record["001"].data = f"({prefix})" + record["001"].data
     return record
+
 
 def prepend_ppn_prefix_001(record: pymarc.Record) -> pymarc.Record:
     """
@@ -29,7 +30,8 @@ def prepend_ppn_prefix_001(record: pymarc.Record) -> pymarc.Record:
     Returns:
         pymarc.Record: The preprocessed MARC record.
     """
-    return prepend_prefix_001(record, 'PPN')
+    return prepend_prefix_001(record, "PPN")
+
 
 def prepend_abes_prefix_001(record: pymarc.Record) -> pymarc.Record:
     """
@@ -42,7 +44,8 @@ def prepend_abes_prefix_001(record: pymarc.Record) -> pymarc.Record:
     Returns:
         pymarc.Record: The preprocessed MARC record.
     """
-    return prepend_prefix_001(record, 'ABES')
+    return prepend_prefix_001(record, "ABES")
+
 
 def strip_999_ff_fields(record: pymarc.Record) -> pymarc.Record:
     """
@@ -55,10 +58,11 @@ def strip_999_ff_fields(record: pymarc.Record) -> pymarc.Record:
     Returns:
         pymarc.Record: The preprocessed MARC record.
     """
-    for field in record.get_fields('999'):
-        if field.indicators == pymarc.Indicators(*['f', 'f']):
+    for field in record.get_fields("999"):
+        if field.indicators == pymarc.Indicators(*["f", "f"]):
             record.remove_field(field)
     return record
+
 
 def sudoc_supercede_prep(record: pymarc.Record) -> pymarc.Record:
     """
@@ -75,21 +79,23 @@ def sudoc_supercede_prep(record: pymarc.Record) -> pymarc.Record:
         pymarc.Record: The preprocessed MARC record.
     """
     record = prepend_abes_prefix_001(record)
-    for field in record.get_fields('035'):
-        if "a" in field and "9" in field and field['9'] == 'sudoc':
+    for field in record.get_fields("035"):
+        if "a" in field and "9" in field and field["9"] == "sudoc":
             _935 = pymarc.Field(
-                tag='935',
-                indicators=['f', 'f'],
-                subfields=[
-                    pymarc.field.Subfield('a', "(ABES)" + field['a'])
-                ]
+                tag="935",
+                indicators=["f", "f"],
+                subfields=[pymarc.field.Subfield("a", "(ABES)" + field["a"])],
             )
             record.add_ordered_field(_935)
     return record
 
+
 def clean_empty_fields(record: pymarc.Record) -> pymarc.Record:
     """
-    Remove all empty fields from the record.
+    Remove empty fields and subfields from the record. These can cause
+    data import mapping issues in FOLIO. Removals are logged at custom
+    log level 26, which is used by folio_migration_tools to populate the
+    data issues report.
 
     Args:
         record (pymarc.Record): The MARC record to preprocess.
@@ -97,13 +103,167 @@ def clean_empty_fields(record: pymarc.Record) -> pymarc.Record:
     Returns:
         pymarc.Record: The preprocessed MARC record.
     """
+    MAPPED_FIELDS = {
+        "010": ["a", "z"],
+        "020": ["a", "y", "z"],
+        "050": ["a", "b"],
+        "082": ["a", "b"],
+        "100": ["a", "b", "c", "d", "q"],
+        "110": ["a", "b", "c"],
+        "111": ["a", "c", "d"],
+        "130": [
+            "a",
+            "d",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s",
+            "t",
+            "x",
+            "y",
+            "z",
+        ],
+        "240": ["a", "f", "k", "l", "m", "n", "o", "p", "r", "s", "t", "x", "y", "z"],
+        "245": ["a", "b", "c", "f", "g", "h", "k", "n", "p", "s"],
+        "246": ["a", "f", "g", "n", "p", "s"],
+        "250": ["a", "b"],
+        "260": ["a", "b", "c", "e", "f", "g"],
+        "300": ["a", "b", "c", "e", "f", "g"],
+        "440": ["a", "n", "p", "v", "x", "y", "z"],
+        "490": ["a", "v", "x", "y", "z"],
+        "500": ["a", "c", "d", "n", "p", "v", "x", "y", "z"],
+        "505": ["a", "g", "r", "t", "u"],
+        "520": ["a", "b", "c", "u"],
+        "600": ["a", "b", "c", "d", "q", "t", "v", "x", "y", "z"],
+        "610": ["a", "b", "c", "d", "t", "v", "x", "y", "z"],
+        "611": ["a", "c", "d", "t", "v", "x", "y", "z"],
+        "630": [
+            "a",
+            "d",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s",
+            "t",
+            "x",
+            "y",
+            "z",
+        ],
+        "650": ["a", "d", "v", "x", "y", "z"],
+        "651": ["a", "v", "x", "y", "z"],
+        "655": ["a", "v", "x", "y", "z"],
+        "700": ["a", "b", "c", "d", "q", "t", "v", "x", "y", "z"],
+        "710": ["a", "b", "c", "d", "t", "v", "x", "y", "z"],
+        "711": ["a", "c", "d", "t", "v", "x", "y", "z"],
+        "730": [
+            "a",
+            "d",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s",
+            "t",
+            "x",
+            "y",
+            "z",
+        ],
+        "740": ["a", "n", "p", "v", "x", "y", "z"],
+        "800": ["a", "b", "c", "d", "q", "t", "v", "x", "y", "z"],
+        "810": ["a", "b", "c", "d", "t", "v", "x", "y", "z"],
+        "811": ["a", "c", "d", "t", "v", "x", "y", "z"],
+        "830": [
+            "a",
+            "d",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s",
+            "t",
+            "x",
+            "y",
+            "z",
+        ],
+        "856": ["u", "y", "z"],
+    }
+
     for field in list(record.get_fields()):
         len_subs = len(field.subfields)
         subfield_value = bool(field.subfields[0].value) if len_subs > 0 else False
-        if int(field.tag) > 9 and len(field.subfields) == 0:
-            logger.log(26, "DATA ISSUE\t%s\t%s\t%s", record["001"].value(), f"{field.tag} is empty", field)
-            record.remove_field(field)
-        if len_subs == 1 and not subfield_value:
-            logger.log(26, "DATA ISSUE\t%s\t%s\t%s", record["001"].value(), f"{field.tag}${field.subfields[0].code} is empty", field)
-            record.remove_field(field)
+        if not int(field.tag) >= 900 and field.tag in MAPPED_FIELDS:
+            if int(field.tag) > 9 and len_subs == 0:
+                logger.log(
+                    26,
+                    "DATA ISSUE\t%s\t%s\t%s",
+                    record["001"].value(),
+                    f"{field.tag} is empty",
+                    field,
+                )
+                record.remove_field(field)
+            elif len_subs == 1 and not subfield_value:
+                logger.log(
+                    26,
+                    "DATA ISSUE\t%s\t%s\t%s",
+                    record["001"].value(),
+                    f"{field.tag}${field.subfields[0].code} is empty, removing field",
+                    field,
+                )
+                record.remove_field(field)
+            else:
+                if len_subs > 1 and "a" in field and not field["a"].strip():
+                    logger.log(
+                        26,
+                        "DATA ISSUE\t%s\t%s\t%s",
+                        record["001"].value(),
+                        f"{field.tag}$a is empty, removing field",
+                        field,
+                    )
+                    field.delete_subfield("a")
+                for idx, subfield in enumerate(list(field.subfields), start=1):
+                    if subfield.code in MAPPED_FIELDS.get(field.tag, []) and not subfield.value:
+                        logger.log(
+                            26,
+                            "DATA ISSUE\t%s\t%s\t%s",
+                            record["001"].value(),
+                            f"{field.tag}${subfield.code} ({ordinal(idx)} subfield) is empty, but other subfields have values, removing subfield",
+                            field,
+                        )
+                        field.delete_subfield(subfield.code)
+                if len(field.subfields) == 0:
+                    logger.log(
+                        26,
+                        "DATA ISSUE\t%s\t%s\t%s",
+                        record["001"].value(),
+                        f"{field.tag} has no non-empty subfields after cleaning, removing field",
+                        field,
+                    )
+                    record.remove_field(field)
     return record
+
+
+def ordinal(n):
+    s = ("th", "st", "nd", "rd") + ("th",) * 10
+    v = n % 100
+    if v > 13:
+        return f"{n}{s[v % 10]}"
+    else:
+        return f"{n}{s[v]}"

--- a/tests/test__preprocessors.py
+++ b/tests/test__preprocessors.py
@@ -45,3 +45,48 @@ def test_sudoc_supercede_prep():
     assert record.get_fields('935')[0]["a"] == '(ABES)234567'
     assert record.get_fields('935')[1]["a"] == '(ABES)345678'
     assert record['001'].data == '(ABES)123456'
+
+
+def test_clean_empty_fields():
+    record = pymarc.Record()
+    record.add_field(pymarc.Field(tag='001', data='123456'))
+    bad_010 = pymarc.Field(tag='010', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('a', '')
+    ])
+    record.add_field(bad_010)
+    good_035 = pymarc.Field(tag='035', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('a', 'ocn123456789')
+    ])
+    record.add_field(good_035)
+    bad_035 = pymarc.Field(tag='035', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('a', '')
+    ])
+    record.add_field(bad_035)
+    bad_650 = pymarc.Field(tag='650', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('a', '')
+    ])
+    record.add_field(bad_650)
+    good_650 = pymarc.Field(tag='650', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('a', 'Test')
+    ])
+    record.add_field(good_650)
+    bad_180 = pymarc.Field(tag='180', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('x', '')
+    ])
+    record.add_field(bad_180)
+    good_180 = pymarc.Field(tag='180', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('x', 'Test')
+    ])
+    record.add_field(good_180)
+    good_245 = pymarc.Field(tag='245', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('a', 'Test: '),
+        pymarc.field.Subfield('b', 'a test / '),
+        pymarc.field.Subfield('c', 'by Test')
+    ])
+    record.add_field(good_245)
+    record = clean_empty_fields(record)
+    assert len(record.get_fields('010')) == 0
+    assert len(record.get_fields('035')) == 1
+    assert len(record.get_fields('650')) == 1
+    assert len(record.get_fields('180')) == 1
+    assert len(record.get_fields('245')) == 1

--- a/tests/test__preprocessors.py
+++ b/tests/test__preprocessors.py
@@ -1,3 +1,4 @@
+from multiprocessing import Value
 from unittest.mock import Mock
 from folioclient import FolioClient
 import pytest
@@ -54,6 +55,16 @@ def test_clean_empty_fields():
         pymarc.field.Subfield('a', '')
     ])
     record.add_field(bad_010)
+    bad_020 = pymarc.Field(tag='020', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('a', ''),
+        pymarc.field.Subfield('y', '0123-4567'),
+    ])
+    record.add_field(bad_020)
+    empty_020 = pymarc.Field(tag='020', indicators=[' ', ' '], subfields=[
+        pymarc.field.Subfield('a', ''),
+        pymarc.field.Subfield('y', ''),
+    ])
+    record.add_field(empty_020)
     good_035 = pymarc.Field(tag='035', indicators=[' ', ' '], subfields=[
         pymarc.field.Subfield('a', 'ocn123456789')
     ])
@@ -90,3 +101,8 @@ def test_clean_empty_fields():
     assert len(record.get_fields('650')) == 1
     assert len(record.get_fields('180')) == 1
     assert len(record.get_fields('245')) == 1
+    assert len(record.get_fields('020')) == 1
+    with pytest.raises(KeyError):
+        record['020']['a']
+    assert record["020"].get("y", "") == "0123-4567"
+


### PR DESCRIPTION
This PR contains the following enhancements:
* Updates how connection and read timeouts (as well as 502 and 504 errors, given the optional `--let-summary-fail` flag) are handled by the MARCDataImport class. 
* Changes out the `print`-based logging for a custom module-level `logging` logger and implements console and file based log handling for script-based invocation.
* Adds new preprocessor to clean some empty fields/subfields that can cause Data Import errors