### PR TITLE
Update 999 preprocessor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folio_data_import"
-version = "0.2.8rc8"
+version = "0.2.8rc9"
 description = "A python module to interact with the data importing capabilities of the open-source FOLIO ILS"
 authors = ["Brooks Travis <brooks.travis@gmail.com>"]
 license = "MIT"

--- a/src/folio_data_import/marc_preprocessors/_preprocessors.py
+++ b/src/folio_data_import/marc_preprocessors/_preprocessors.py
@@ -63,6 +63,29 @@ def strip_999_ff_fields(record: pymarc.Record) -> pymarc.Record:
             record.remove_field(field)
     return record
 
+def clean_999_fields(record: pymarc.Record) -> pymarc.Record:
+    """
+    The presence of 999 fields, with or without ff indicators, can cause
+    issues with data import mapping in FOLIO. This function calls strip_999_ff_fields
+    to remove 999 fields with ff indicators and then copies the remaining 999 fields
+    to 945 fields.
+
+    Args:
+        record (pymarc.Record): The MARC record to preprocess.
+
+    Returns:
+        pymarc.Record: The preprocessed MARC record.
+    """
+    record = strip_999_ff_fields(record)
+    for field in record.get_fields("999"):
+        _945 = pymarc.Field(
+            tag="945",
+            indicators=field.indicators,
+            subfields=field.subfields,
+        )
+        record.add_ordered_field(_945)
+        record.remove_field(field)
+    return record
 
 def sudoc_supercede_prep(record: pymarc.Record) -> pymarc.Record:
     """


### PR DESCRIPTION
Add additional preprocessor to clean additional 999 fields (without ff indicators) to avoid externalId mapping issue with SRS record creation.