### PR TITLE
Fix get job status on single payload jobs and make read_total_records a static method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folio_data_import"
-version = "0.2.8rc10"
+version = "0.2.8rc11"
 description = "A python module to interact with the data importing capabilities of the open-source FOLIO ILS"
 authors = ["Brooks Travis <brooks.travis@gmail.com>"]
 license = "MIT"

--- a/src/folio_data_import/MARCDataImport.py
+++ b/src/folio_data_import/MARCDataImport.py
@@ -327,7 +327,8 @@ class MARCImportJob:
             )
             raise e
 
-    async def read_total_records(self, files) -> int:
+    @staticmethod
+    async def read_total_records(files) -> int:
         """
         Reads the total number of records from the given files.
 

--- a/src/folio_data_import/MARCDataImport.py
+++ b/src/folio_data_import/MARCDataImport.py
@@ -388,6 +388,7 @@ class MARCImportJob:
                     self.error_records += len(self.record_batch)
                     self.pbar_sent.total = self.pbar_sent.total - len(self.record_batch)
                 self.record_batch = []
+        await self.get_job_status()
         sleep(self.batch_delay)
 
     async def process_records(self, files, total_records) -> None:
@@ -419,7 +420,6 @@ class MARCImportJob:
                             == (total_records - self.error_records),
                         ),
                     )
-                    await self.get_job_status()
                     sleep(0.25)
                 if record:
                     if self.marc_record_preprocessor:


### PR DESCRIPTION
Fix an issue where job status retrieval hangs after send is complete when total records is less than chunk size. Also makes read_total_records a static method to let it be used without instantiating the MARCImport class.