### PR TITLE
Fix preprocessors and update MARCDataImport entrypoint in __main__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folio_data_import"
-version = "0.3.2"
+version = "0.3.3"
 description = "A python module to interact with the data importing capabilities of the open-source FOLIO ILS"
 authors = ["Brooks Travis <brooks.travis@gmail.com>"]
 license = "MIT"

--- a/src/folio_data_import/__main__.py
+++ b/src/folio_data_import/__main__.py
@@ -43,14 +43,6 @@ async def main():
         default=0.0,
     )
     parser.add_argument(
-        "--consolidate",
-        action="store_true",
-        help=(
-            "Consolidate records into a single job. "
-            "Default is to create a new job for each MARC file."
-        ),
-    )
-    parser.add_argument(
         "--no-progress",
         action="store_true",
         help="Disable progress bars (eg. for running in a CI environment)",
@@ -92,7 +84,6 @@ async def main():
                 args.import_profile_name,
                 batch_size=args.batch_size,
                 batch_delay=args.batch_delay,
-                consolidate=bool(args.consolidate),
                 no_progress=bool(args.no_progress),
             ).do_work()
         except Exception as e:

--- a/src/folio_data_import/marc_preprocessors/_preprocessors.py
+++ b/src/folio_data_import/marc_preprocessors/_preprocessors.py
@@ -9,12 +9,13 @@ from pymarc.record import Record
 
 logger = logging.getLogger("folio_data_import.MARCDataImport")
 
+
 class MARCPreprocessor:
     """
     A class to preprocess MARC records for data import into FOLIO.
     """
 
-    def __init__(self, preprocessors: Union[str,List[Callable]], **kwargs):
+    def __init__(self, preprocessors: Union[str, List[Callable]], **kwargs):
         """
         Initialize the MARCPreprocessor with a list of preprocessors.
 
@@ -416,7 +417,7 @@ def clean_empty_fields(record: Record, **kwargs) -> Record:
     return record
 
 
-def fix_leader(record: Record, **kwargs) -> Record:
+def fix_bib_leader(record: Record, **kwargs) -> Record:
     """
     Fixes the leader of the record by setting the record status to 'c' (modified
     record) and the type of record to 'a' (language material).
@@ -449,6 +450,7 @@ def fix_leader(record: Record, **kwargs) -> Record:
         record.leader = pymarc.Leader(record.leader[:6] + "a" + record.leader[7:])
     return record
 
+
 def move_authority_subfield_9_to_0_all_controllable_fields(record: Record, **kwargs) -> Record:
     """
     Move subfield 9 from authority fields to subfield 0. This is useful when
@@ -461,13 +463,14 @@ def move_authority_subfield_9_to_0_all_controllable_fields(record: Record, **kwa
         Record: The preprocessed MARC record.
     """
     controlled_fields = [
-            "100", "110", "111", "130",
-            "600", "610", "611", "630", "650", "651", "655",
-            "700", "710", "711", "730",
-            "800", "810", "811", "830", "880"
-        ]
+        "100", "110", "111", "130",
+        "600", "610", "611", "630", "650", "651", "655",
+        "700", "710", "711", "730",
+        "800", "810", "811", "830", "880"
+    ]
     for field in record.get_fields(*controlled_fields):
-        for subfield in list(field.get_subfields("9")):
+        _subfields = field.get_subfields("9")
+        for subfield in _subfields:
             field.add_subfield("0", subfield)
             field.delete_subfield("9")
             logger.log(
@@ -478,6 +481,7 @@ def move_authority_subfield_9_to_0_all_controllable_fields(record: Record, **kwa
                 field,
             )
     return record
+
 
 def ordinal(n):
     s = ("th", "st", "nd", "rd") + ("th",) * 10

--- a/tests/test__preprocessors.py
+++ b/tests/test__preprocessors.py
@@ -10,6 +10,7 @@ def test_prepend_ppn_prefix_001():
     record = processor.do_work(record)
     assert record['001'].data == '(PPN)123456'
 
+
 def test_prepend_abes_prefix_001():
     processor = MARCPreprocessor("prepend_abes_prefix_001")
     record = pymarc.Record()
@@ -17,11 +18,13 @@ def test_prepend_abes_prefix_001():
     record = processor.do_work(record)
     assert record['001'].data == '(ABES)123456'
 
+
 def test_prepend_prefix_001():
     record = pymarc.Record()
     record.add_field(pymarc.Field(tag='001', data='123456'))
     record = prepend_prefix_001(record, 'TEST')
     assert record['001'].data == '(TEST)123456'
+
 
 def test_strip_999_ff_fields():
     processor = MARCPreprocessor("strip_999_ff_fields")
@@ -30,6 +33,7 @@ def test_strip_999_ff_fields():
     record.add_field(pymarc.Field(tag='999', indicators=[' ', ' ']))
     record = processor.do_work(record)
     assert len(record.get_fields('999')) == 1
+
 
 def test_sudoc_supercede_prep():
     processor = MARCPreprocessor("sudoc_supercede_prep")
@@ -108,8 +112,8 @@ def test_clean_empty_fields():
         record['020']['a']
     assert record["020"].get("y", "") == "0123-4567"
 
-def test_fix_leader():
-    preprocessor = MARCPreprocessor("fix_leader")
+def test_fix_bib_leader():
+    preprocessor = MARCPreprocessor("fix_bib_leader")
     record = pymarc.Record()
     record.leader = pymarc.Leader('01234mbm a2200349 a 4500')
     fields=[


### PR DESCRIPTION
Rename `fix_leader` to `fix_bib_leader`, remove the `--consolidate` option, and enhance the MARCDataImport functionality by adding a job ID file output. Update the version to 0.3.3.