### PR TITLE
Add `--no-progress` option to UserImport CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.poetry]
 name = "folio_data_import"
 version = "0.4.1"
-description = "A python module to interact with the data importing capabilities of the open-source FOLIO ILS"
+description = "A python module to perform bulk import of data into a FOLIO environment. Currently supports MARC and user data import."
 authors = ["Brooks Travis <brooks.travis@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "folio_data_import", from="src"}]
+packages = [{ include = "folio_data_import", from = "src" }]
 
 [tool.poetry.scripts]
 folio-data-import = "folio_data_import.__main__:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folio_data_import"
-version = "0.4.0"
+version = "0.4.1"
 description = "A python module to interact with the data importing capabilities of the open-source FOLIO ILS"
 authors = ["Brooks Travis <brooks.travis@gmail.com>"]
 license = "MIT"

--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -1113,7 +1113,7 @@ def main(
     no_progress: bool = typer.Option(
         False,
         "--no-progress",
-        help="Do not display the progress bar",
+        help="Disable progress bar display during user import",
     ),
 ) -> None:
     """


### PR DESCRIPTION
Introduce a command-line option to control the visibility of the progress bar during user import operations. This enhancement allows users to suppress the progress display if desired.