### PR TITLE
Add FOLIO-specific exception handling and bump version to 0.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_data_import"
-version = "0.5.2"
+version = "0.5.3"
 description = "A python module to perform bulk import of data into a FOLIO environment. Currently supports MARC and user data import."
 authors = [{ name = "Brooks Travis", email = "brooks.travis@gmail.com" }]
 license = "MIT"

--- a/src/folio_data_import/BatchPoster.py
+++ b/src/folio_data_import/BatchPoster.py
@@ -19,6 +19,7 @@ import cyclopts
 import folioclient
 import httpx
 from folioclient import FolioClient
+from folioclient.exceptions import folio_errors
 from pydantic import BaseModel, Field
 
 from folio_data_import import get_folio_connection_parameters, set_up_cli_logging
@@ -650,6 +651,7 @@ class BatchPoster:
             if "id" in record and record["id"] in existing_records:
                 self.prepare_record_for_upsert(record, existing_records[record["id"]])
 
+    @folio_errors
     async def post_batch(self, batch: List[dict]) -> tuple[httpx.Response, int, int]:
         """
         Post a batch of records to FOLIO.


### PR DESCRIPTION
Introduce exception handling for the `post_batch` method in the BatchPoster class to improve error management specific to FOLIO. Update the version to 0.5.3 to reflect these changes.