### PR TITLE
Fix user record update behavior and add deletion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ folio-data-import users --user-file users.jsonl --user-match-key username
 folio-data-import users --user-file users.jsonl --default-preferred-contact-type email
 ```
 
+**Update Behavior:** Control how existing records are updated:
+
+- **Full replacement** (default): The incoming record completely replaces the existing record. Fields present in the existing record but absent from the incoming record are removed. The preferred contact type is preserved from the existing record when not specified in the incoming record.
+  ```shell
+  folio-data-import users --user-file users.jsonl
+  ```
+
+- **Partial update**: Only fields present in the incoming record are updated; missing fields are preserved from the existing record.
+  ```shell
+  folio-data-import users --user-file users.jsonl --update-only-present-fields
+  ```
+
 **Field Protection:** Protect specific fields from being updated:
 
 - **Job-level protection** (applies to all records):
@@ -166,6 +178,16 @@ folio-data-import users --user-file users.jsonl --default-preferred-contact-type
     }
   }
   ```
+
+**User Deletion:** Delete users listed in the input file(s) instead of creating or updating them:
+```shell
+folio-data-import users --user-file users.jsonl --delete-all
+```
+
+- Only users that exist in FOLIO and match via the configured match key are deleted
+- Staff and system users are automatically skipped to prevent accidental removal
+- Associated request preferences, permission user records, and service point assignments are also removed
+- A 10-second delay is applied before deletions begin
 
 #### Input Format
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ folio-data-import users --user-file users.jsonl --default-preferred-contact-type
 
 **Update Behavior:** Control how existing records are updated:
 
+> **⚠️ Breaking change in v0.6.0:** Prior versions incorrectly merged incoming records into existing records, preserving fields absent from the incoming data. Starting in v0.6.0, the default behavior is full replacement — fields not present in the incoming record are removed. If you depend on the previous merge behavior, use `--update-only-present-fields`.
+
 - **Full replacement** (default): The incoming record completely replaces the existing record. Fields present in the existing record but absent from the incoming record are removed. The preferred contact type is preserved from the existing record when not specified in the incoming record.
   ```shell
   folio-data-import users --user-file users.jsonl
@@ -187,7 +189,7 @@ folio-data-import users --user-file users.jsonl --delete-all
 - Only users that exist in FOLIO and match via the configured match key are deleted
 - Staff and system users are automatically skipped to prevent accidental removal
 - Associated request preferences, permission user records, and service point assignments are also removed
-- A 10-second delay is applied before deletions begin
+- An interactive confirmation prompt is displayed before deletions begin; use `--yes`/`-y` to skip it (required in non-interactive environments)
 
 #### Input Format
 

--- a/docs/source/user_import_guide.md
+++ b/docs/source/user_import_guide.md
@@ -79,6 +79,7 @@ Example `config.json`:
 | `--limit-async-requests` | `FOLIO_LIMIT_ASYNC_REQUESTS` | 10 | Max concurrent HTTP requests (1-100) |
 | `--report-file-base-path` | - | Current directory | Base path for report files |
 | `--config-file` | - | (none) | Path to JSON config file (overrides CLI parameters) |
+| `--yes` / `-y` | - | `false` | Skip confirmation prompt for destructive operations (e.g. `--delete-all`) |
 | `--no-progress` | - | `false` | Disable progress display |
 
 ### Preferred Contact Types
@@ -232,6 +233,12 @@ When enabled, missing fields in the input are preserved from the existing record
 
 When **disabled** (the default), the incoming record completely **replaces** the existing record. Only the user's `id` is preserved from the original; all other fields come from the incoming record. Any fields present in the existing record but absent from the incoming record are removed. Protected fields (via `--fields-to-protect` or per-record `customFields.protectedFields`) are always re-applied after the replacement.
 
+```{warning}
+**Breaking change in v0.6.0:** Prior to v0.6.0, the default update behavior incorrectly *merged* the incoming record into the existing record, preserving any fields absent from the incoming data. This was an implementation defect — it did not match the tool's stated full-replacement semantics. Starting in v0.6.0, the default behavior correctly performs a full replacement: only the user's `id` is carried over from the existing record, and all other fields are taken from the incoming record. Fields present in the existing record but missing from the incoming record are removed.
+
+If your workflow relied on the previous merge behavior, add `--update-only-present-fields` to preserve the old behavior.
+```
+
 ```{note}
 The preferred contact type is also preserved from the existing record when the incoming record does not include a `preferredContactTypeId`. The configured default is only applied when neither the incoming nor the existing record has a valid value.
 ```
@@ -276,7 +283,7 @@ The `--delete-all` CLI flag overrides the config file value when both are specif
    - Associated request preferences (`/request-preference-storage/request-preference/{id}`)
    - Associated permission user record (`/perms/users/{id}`)
    - Associated service points user record (`/service-points-users/{id}`)
-5. A 10-second delay is applied before deletions begin as a safety measure. Use `Ctrl+C` to abort, if desired.
+5. An interactive confirmation prompt is displayed before deletions begin. Press Enter to proceed or `Ctrl+C` to abort. Use `--yes`/`-y` to skip the prompt (required in non-interactive environments such as CI/CD pipelines or cron jobs).
 
 ### Deletion Statistics
 

--- a/docs/source/user_import_guide.md
+++ b/docs/source/user_import_guide.md
@@ -277,7 +277,7 @@ The `--delete-all` CLI flag overrides the config file value when both are specif
 
 1. Each user in the input file is matched against FOLIO using the configured match key
 2. If a matching user is found, the tool checks the user's `type` field
-3. **Staff** and **system** users are automatically skipped to prevent accidental removal
+3. **Staff**, **dcb**, **shadow**, and **system** users are automatically skipped to prevent accidental removal
 4. For eligible users (e.g., `patron` type), the following records are deleted:
    - The user record itself (`/users/{id}`)
    - Associated request preferences (`/request-preference-storage/request-preference/{id}`)

--- a/docs/source/user_import_guide.md
+++ b/docs/source/user_import_guide.md
@@ -12,8 +12,9 @@ User Import:
 - Handles service point assignments via the `/service-points-users` API
 - Creates request preferences and permission user records for new users
 - Provides job-level and per-record field protection during updates
-- Supports partial updates (only update present fields)
+- Supports partial updates (only update present fields) or full record replacement (default)
 - Offers flexible user matching (username, barcode, externalSystemId) with forced matching on `id`
+- Bulk deletion of matched users via `--delete-all` (staff and system users are protected)
 - Batch processing with real-time progress tracking
 
 ## Basic Usage
@@ -74,6 +75,7 @@ Example `config.json`:
 | `--default-preferred-contact-type` | - | `email` | Default contact type (see table below) |
 | `--fields-to-protect` | `FOLIO_FIELDS_TO_PROTECT` | (none) | Comma-separated list of field paths to protect |
 | `--update-only-present-fields` | - | `false` | Only update fields present in input |
+| `--delete-all` | `FOLIO_DELETE_ALL_USERS` | `false` | Delete users in file(s) instead of creating/updating |
 | `--limit-async-requests` | `FOLIO_LIMIT_ASYNC_REQUESTS` | 10 | Max concurrent HTTP requests (1-100) |
 | `--report-file-base-path` | - | Current directory | Base path for report files |
 | `--config-file` | - | (none) | Path to JSON config file (overrides CLI parameters) |
@@ -228,6 +230,61 @@ folio-data-import users \
 
 When enabled, missing fields in the input are preserved from the existing record rather than being cleared. This is useful for targeted updates.
 
+When **disabled** (the default), the incoming record completely **replaces** the existing record. Only the user's `id` is preserved from the original; all other fields come from the incoming record. Any fields present in the existing record but absent from the incoming record are removed. Protected fields (via `--fields-to-protect` or per-record `customFields.protectedFields`) are always re-applied after the replacement.
+
+```{note}
+The preferred contact type is also preserved from the existing record when the incoming record does not include a `preferredContactTypeId`. The configured default is only applied when neither the incoming nor the existing record has a valid value.
+```
+
+## User Deletion
+
+```{warning}
+Use this feature with caution. No dependency checks are performed before a user is deleted, so this could result in orphaned circulation transactions and other unexpected system behavior.
+```
+
+The `--delete-all` flag changes the tool from import mode to deletion mode. Instead of creating or updating users, it deletes users found in the input file(s) from FOLIO:
+
+```bash
+folio-data-import users \
+  --library-name "My Library" \
+  --user-file-path users_to_delete.jsonl \
+  --delete-all
+```
+
+Or via a config file:
+
+```json
+{
+  "library_name": "My Library",
+  "user_file_paths": ["users_to_delete.jsonl"],
+  "user_match_key": "username",
+  "delete_all": true
+}
+```
+
+```{note}
+The `--delete-all` CLI flag overrides the config file value when both are specified.
+```
+
+### How Deletion Works
+
+1. Each user in the input file is matched against FOLIO using the configured match key
+2. If a matching user is found, the tool checks the user's `type` field
+3. **Staff** and **system** users are automatically skipped to prevent accidental removal
+4. For eligible users (e.g., `patron` type), the following records are deleted:
+   - The user record itself (`/users/{id}`)
+   - Associated request preferences (`/request-preference-storage/request-preference/{id}`)
+   - Associated permission user record (`/perms/users/{id}`)
+   - Associated service points user record (`/service-points-users/{id}`)
+5. A 10-second delay is applied before deletions begin as a safety measure. Use `Ctrl+C` to abort, if desired.
+
+### Deletion Statistics
+
+Deletion progress is tracked alongside other statistics:
+- **Deleted**: Users successfully removed
+- **Failed**: Users that could not be deleted (e.g., due to API errors)
+- Staff/system users that are skipped are not counted in either category
+
 ## Service Point Assignment
 
 Assign service points using codes (resolved automatically) or UUIDs:
@@ -304,6 +361,7 @@ folio-data-import users \
 Real-time progress bars show:
 - Total users processed
 - Successful creates/updates
+- Deleted users (when using `--delete-all`)
 - Failed imports
 - Processing speed and time
 
@@ -385,15 +443,18 @@ folio-data-import users \
 |---------|-----------------|-------------------------|
 | Input format | Wrapped JSON with `users` array | JSON Lines (one user object per line) |
 | API approach | Single POST to `/user-import` | Individual POST/PUT to `/users` |
-| Service points | N/A | Codes or UUIDs via `/service-points-users` |
-| Field protection | `updateOnlyPresentFields` for addresses | Job-level and per-record for any field |
+| Service points assignment | N/A | User assignments via `/service-points-users` |
+| Field protection | `updateOnlyPresentFields` (top-level fields preserved; addresses deep-merged by type) | Job-level and per-record for any field |
 | Contact type | `mail`, `email`, `text`, `phone`, `mobile` | Same values plus IDs (`001`-`005`) |
 | Match key | `externalSystemId` only | Configurable with forced matching on `id` |
 | Custom fields | Can define and manage via `included` | Values only (definitions must exist in FOLIO) |
 | Departments | Can create via `included` | Values only (must already exist in FOLIO) |
+| Request preferences | Per-user with delivery/fulfillment settings | Auto-created for new users |
 | Batch processing | Single request | Configurable batch size (default 250) |
 | Progress tracking | None | Real-time progress bars |
 | Concurrent requests | N/A | Configurable (default 10, max 100) |
+| Bulk deletion | Deactivation only (`deactivateMissingUsers`) | `--delete-all` flag (skips staff/system users) |
+| Update behavior | Full replacement (default) or partial update (top-level fields + address deep merge) | Full replacement (default) or partial update (all fields) |
 
 ## See Also
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folio_data_import"
-version = "0.5.3"
+version = "0.6.0"
 description = "A python module to perform bulk import of data into a FOLIO environment. Currently supports MARC and user data import."
 authors = [{ name = "Brooks Travis", email = "brooks.travis@gmail.com" }]
 license = "MIT"

--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -793,7 +793,7 @@ class UserImporter:  # noqa: R0902
         Returns:
             None
         """
-        if existing_user.get("type", "") in ["staff", "system"]:
+        if existing_user.get("type", "") in ["staff", "system", "shadow", "dcb"]:
             logger.warning(
                 f"Row {line_number}: User {existing_user['id']} "
                 f"is of type {existing_user.get('type', '')}, "
@@ -1261,8 +1261,10 @@ def main(
             "--delete-all flag is set. Users present in the provided file(s) will be "
             "deleted rather than created or updated. Proceed with caution."
         )
-        print("Waiting 10 seconds before proceeding with deletions...")
-        sleep(10)
+        for i in range(10, 0, -1):
+            print(f"\rProceeding with deletions in {i} seconds...", end="", flush=True)
+            sleep(1)
+        print("\rProceeding with deletions now.                ")
 
     config_data = {}
     if config_file:

--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -801,17 +801,19 @@ class UserImporter:  # noqa: R0902
             return
         try:
             if existing_user:
-                await self.folio_client.folio_delete(
+                await self.folio_client.folio_delete_async(
                     f"/users/{existing_user['id']}",
                 )
             if existing_rp:
-                await self.folio_client.folio_delete(
+                await self.folio_client.folio_delete_async(
                     f"/request-preference-storage/request-preference/{existing_rp.get('id', '')}"
                 )
             if existing_pu:
-                await self.folio_client.folio_delete(f"/perms/users/{existing_pu.get('id', '')}")
+                await self.folio_client.folio_delete_async(
+                    f"/perms/users/{existing_pu.get('id', '')}"
+                )
             if existing_spu:
-                await self.folio_client.folio_delete(
+                await self.folio_client.folio_delete_async(
                     f"/service-points-users/{existing_spu.get('id', '')}"
                 )
 
@@ -858,14 +860,11 @@ class UserImporter:  # noqa: R0902
                 existing_pu,
                 existing_spu,
             ) = await self.process_existing_user(user_obj)
-            if (
-                self.config.delete_all
-                and existing_user
-                and existing_user.get("type", "") not in ["staff", "system"]
-            ):
-                await self.delete_user(
-                    existing_user, existing_rp, existing_pu, existing_spu, line_number
-                )
+            if self.config.delete_all:
+                if existing_user:
+                    await self.delete_user(
+                        existing_user, existing_rp, existing_pu, existing_spu, line_number
+                    )
                 return
             await self.map_address_types(user_obj, line_number)
             await self.map_patron_groups(user_obj, line_number)
@@ -1038,10 +1037,11 @@ class UserImporter:  # noqa: R0902
             total_lines = sum(buf.count(b"\n") for buf in iter(lambda: f.read(1024 * 1024), b""))
 
         with self.reporter:
+            description = "Deleting users" if self.config.delete_all else "Importing users"
             task_id = self.reporter.start_task(
                 "users",
                 total=total_lines,
-                description="Importing users",
+                description=description,
             )
             openfile.seek(0)
             tasks = []
@@ -1052,21 +1052,33 @@ class UserImporter:  # noqa: R0902
                     await asyncio.gather(*tasks)
                     duration = time.time() - start
                     async with self.lock:
-                        self.reporter.update_task(
-                            task_id,
-                            advance=len(tasks),
-                            created=self.stats.created,
-                            updated=self.stats.updated,
-                            failed=self.stats.failed,
-                            deleted=self.stats.deleted,
-                        )
-                        message = (
-                            f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
-                            f"Batch of {self.config.batch_size} users processed in {duration:.2f} "
-                            f"seconds. - Users created: {self.stats.created} - Users updated: "
-                            f"{self.stats.updated} - Users deleted: {self.stats.deleted}"
-                            f" - Users failed: {self.stats.failed}"
-                        )
+                        if self.config.delete_all:
+                            self.reporter.update_task(
+                                task_id,
+                                advance=len(tasks),
+                                deleted=self.stats.deleted,
+                                failed=self.stats.failed,
+                            )
+                            message = (
+                                f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
+                                f"Batch of {self.config.batch_size} users processed in {duration:.2f} "
+                                f"seconds. - Users deleted: {self.stats.deleted}"
+                                f" - Users failed: {self.stats.failed}"
+                            )
+                        else:
+                            self.reporter.update_task(
+                                task_id,
+                                advance=len(tasks),
+                                created=self.stats.created,
+                                updated=self.stats.updated,
+                                failed=self.stats.failed,
+                            )
+                            message = (
+                                f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
+                                f"Batch of {self.config.batch_size} users processed in {duration:.2f} "
+                                f"seconds. - Users created: {self.stats.created} - Users updated: "
+                                f"{self.stats.updated} - Users failed: {self.stats.failed}"
+                            )
                         logger.info(message)
                     tasks = []
             if tasks:
@@ -1074,21 +1086,33 @@ class UserImporter:  # noqa: R0902
                 await asyncio.gather(*tasks)
                 duration = time.time() - start
                 async with self.lock:
-                    self.reporter.update_task(
-                        task_id,
-                        advance=len(tasks),
-                        created=self.stats.created,
-                        updated=self.stats.updated,
-                        failed=self.stats.failed,
-                        deleted=self.stats.deleted,
-                    )
-                    message = (
-                        f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
-                        f"Batch of {len(tasks)} users processed in {duration:.2f} seconds. - "
-                        f"Users created: {self.stats.created} - Users updated: "
-                        f"{self.stats.updated} - Users deleted: {self.stats.deleted}"
-                        f" - Users failed: {self.stats.failed}"
-                    )
+                    if self.config.delete_all:
+                        self.reporter.update_task(
+                            task_id,
+                            advance=len(tasks),
+                            deleted=self.stats.deleted,
+                            failed=self.stats.failed,
+                        )
+                        message = (
+                            f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
+                            f"Batch of {len(tasks)} users processed in {duration:.2f} seconds. - "
+                            f"Users deleted: {self.stats.deleted}"
+                            f" - Users failed: {self.stats.failed}"
+                        )
+                    else:
+                        self.reporter.update_task(
+                            task_id,
+                            advance=len(tasks),
+                            created=self.stats.created,
+                            updated=self.stats.updated,
+                            failed=self.stats.failed,
+                        )
+                        message = (
+                            f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
+                            f"Batch of {len(tasks)} users processed in {duration:.2f} seconds. - "
+                            f"Users created: {self.stats.created} - Users updated: "
+                            f"{self.stats.updated} - Users failed: {self.stats.failed}"
+                        )
                     logger.info(message)
 
     def get_stats(self) -> UserImporterStats:
@@ -1271,9 +1295,7 @@ def main(
         )
         if not yes:
             if not sys.stdin.isatty():
-                logger.critical(
-                    "--delete-all requires --yes/-y flag in non-interactive mode."
-                )
+                logger.critical("--delete-all requires --yes/-y flag in non-interactive mode.")
                 sys.exit(1)
             input("Press Enter to proceed with deletions, or Ctrl+C to abort...")
 

--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -1,4 +1,3 @@
-from time import sleep
 import asyncio
 import datetime
 import glob
@@ -1207,6 +1206,14 @@ def main(
         cyclopts.Parameter(group="Job Configuration Parameters"),
     ] = "email",
     no_progress: Annotated[bool, cyclopts.Parameter(group="Job Configuration Parameters")] = False,
+    yes: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--yes", "-y"],
+            group="Job Configuration Parameters",
+            help="Skip confirmation prompt for destructive operations (e.g. --delete-all).",
+        ),
+    ] = False,
     debug: Annotated[
         bool,
         cyclopts.Parameter(
@@ -1236,6 +1243,7 @@ def main(
         user_match_key (str): The key to match users (externalSystemId, username, barcode).
         default_preferred_contact_type (str): The default preferred contact type for users
         no_progress (bool): Whether to disable the progress bar.
+        yes (bool): Skip confirmation prompt for destructive operations (e.g. --delete-all).
         debug (bool): Enable debug logging.
     """  # noqa: E501
     set_up_cli_logging(logger, "folio_user_import", debug, stream_level=logging.WARNING)
@@ -1261,10 +1269,13 @@ def main(
             "--delete-all flag is set. Users present in the provided file(s) will be "
             "deleted rather than created or updated. Proceed with caution."
         )
-        for i in range(10, 0, -1):
-            print(f"\rProceeding with deletions in {i} seconds...", end="", flush=True)
-            sleep(1)
-        print("\rProceeding with deletions now.                ")
+        if not yes:
+            if not sys.stdin.isatty():
+                logger.critical(
+                    "--delete-all requires --yes/-y flag in non-interactive mode."
+                )
+                sys.exit(1)
+            input("Press Enter to proceed with deletions, or Ctrl+C to abort...")
 
     config_data = {}
     if config_file:

--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -1,3 +1,4 @@
+from time import sleep
 import asyncio
 import datetime
 import glob
@@ -53,6 +54,7 @@ class UserImporterStats(BaseModel):
     created: int = 0
     updated: int = 0
     failed: int = 0
+    deleted: int = 0
 
 
 class UserImporter:  # noqa: R0902
@@ -141,6 +143,13 @@ class UserImporter:  # noqa: R0902
             Field(
                 title="No progress bar",
                 description="Disable the progress bar display",
+            ),
+        ] = False
+        delete_all: Annotated[
+            bool,
+            Field(
+                title="Delete all users in file(s)",
+                description="Whether to delete existing users, rather than create/update.",
             ),
         ] = False
 
@@ -475,7 +484,7 @@ class UserImporter:  # noqa: R0902
             if existing_personal:
                 existing_user["personal"] = existing_personal
         else:
-            existing_user.update(user_obj)
+            existing_user = {"id": existing_user["id"], **user_obj}
         if "personal" in existing_user:
             existing_user["personal"].update(preferred_contact_type)
         else:
@@ -769,6 +778,57 @@ class UserImporter:  # noqa: R0902
         )
         response.raise_for_status()
 
+    async def delete_user(
+        self, existing_user, existing_rp, existing_pu, existing_spu, line_number: int
+    ) -> None:
+        """
+        Deletes a user and associated objects.
+
+        Args:
+            existing_user (dict): The existing user object to be deleted.
+            existing_rp (dict): The existing request preference object associated with the user.
+            existing_pu (dict): The existing permission user object associated with the user.
+            existing_spu (dict): The existing service points user object associated with the user.
+            line_number (int): The line number in the input file for logging purposes.
+        Returns:
+            None
+        """
+        if existing_user.get("type", "") in ["staff", "system"]:
+            logger.warning(
+                f"Row {line_number}: User {existing_user['id']} "
+                f"is of type {existing_user.get('type', '')}, "
+                "skipping deletion\n"
+            )
+            return
+        try:
+            if existing_user:
+                await self.folio_client.folio_delete(
+                    f"/users/{existing_user['id']}",
+                )
+            if existing_rp:
+                await self.folio_client.folio_delete(
+                    f"/request-preference-storage/request-preference/{existing_rp.get('id', '')}"
+                )
+            if existing_pu:
+                await self.folio_client.folio_delete(f"/perms/users/{existing_pu.get('id', '')}")
+            if existing_spu:
+                await self.folio_client.folio_delete(
+                    f"/service-points-users/{existing_spu.get('id', '')}"
+                )
+
+            if existing_user:
+                logger.debug(f"Row {line_number}: Deleted user {existing_user['id']}\n")
+
+            async with self.lock:
+                self.stats.deleted += 1
+        except folioclient.FolioError as ee:
+            logger.error(
+                f"Row {line_number}: Failed to delete user {existing_user['id']}: "
+                f"{str(getattr(getattr(ee, 'response', str(ee)), 'text', str(ee)))}\n"
+            )
+            async with self.lock:
+                self.stats.failed += 1
+
     async def process_line(
         self,
         user: str,
@@ -799,6 +859,15 @@ class UserImporter:  # noqa: R0902
                 existing_pu,
                 existing_spu,
             ) = await self.process_existing_user(user_obj)
+            if (
+                self.config.delete_all
+                and existing_user
+                and existing_user.get("type", "") not in ["staff", "system"]
+            ):
+                await self.delete_user(
+                    existing_user, existing_rp, existing_pu, existing_spu, line_number
+                )
+                return
             await self.map_address_types(user_obj, line_number)
             await self.map_patron_groups(user_obj, line_number)
             await self.map_departments(user_obj, line_number)
@@ -990,12 +1059,14 @@ class UserImporter:  # noqa: R0902
                             created=self.stats.created,
                             updated=self.stats.updated,
                             failed=self.stats.failed,
+                            deleted=self.stats.deleted,
                         )
                         message = (
                             f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
                             f"Batch of {self.config.batch_size} users processed in {duration:.2f} "
                             f"seconds. - Users created: {self.stats.created} - Users updated: "
-                            f"{self.stats.updated} - Users failed: {self.stats.failed}"
+                            f"{self.stats.updated} - Users deleted: {self.stats.deleted}"
+                            f" - Users failed: {self.stats.failed}"
                         )
                         logger.info(message)
                     tasks = []
@@ -1010,12 +1081,14 @@ class UserImporter:  # noqa: R0902
                         created=self.stats.created,
                         updated=self.stats.updated,
                         failed=self.stats.failed,
+                        deleted=self.stats.deleted,
                     )
                     message = (
                         f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
                         f"Batch of {len(tasks)} users processed in {duration:.2f} seconds. - "
                         f"Users created: {self.stats.created} - Users updated: "
-                        f"{self.stats.updated} - Users failed: {self.stats.failed}"
+                        f"{self.stats.updated} - Users deleted: {self.stats.deleted}"
+                        f" - Users failed: {self.stats.failed}"
                     )
                     logger.info(message)
 
@@ -1087,6 +1160,14 @@ def main(
             group="FOLIO Connection Parameters",
         ),
     ] = None,
+    delete_all: Annotated[
+        bool,
+        cyclopts.Parameter(
+            env_var="FOLIO_DELETE_ALL_USERS",
+            show_env_var=True,
+            group="Job Configuration Parameters",
+        ),
+    ] = False,
     fields_to_protect: Annotated[
         str | None,
         cyclopts.Parameter(
@@ -1146,6 +1227,7 @@ def main(
         user_file_paths (Tuple[Path, ...]): Path(s) to the user data file(s). Use
             --user-file-paths or --user-file-path (deprecated, will be removed in future versions).
         member_tenant_id (str): The FOLIO ECS member tenant id (if applicable).
+        delete_all (bool): Whether to delete existing users, rather than create/update.
         fields_to_protect (str): Comma-separated list of fields to protect during update.
         update_only_present_fields (bool): Whether to update only fields present in the input.
         limit_async_requests (int): The maximum number of concurrent async HTTP requests.
@@ -1174,11 +1256,21 @@ def main(
         report_file_base_path / f"failed_user_import_{dt.now(utc).strftime('%Y%m%d_%H%M%S')}.txt"
     )
 
+    if delete_all:
+        logger.warning(
+            "--delete-all flag is set. Users present in the provided file(s) will be "
+            "deleted rather than created or updated. Proceed with caution."
+        )
+        print("Waiting 10 seconds before proceeding with deletions...")
+        sleep(10)
+
     config_data = {}
     if config_file:
         try:
             with open(config_file, "r") as f:
                 config_data = json.load(f)
+                # CLI flags override config file values
+                config_data["delete_all"] = delete_all or config_data.get("delete_all", False)
                 config = UserImporter.Config(**config_data)
         except Exception as e:
             logger.critical(f"Failed to load configuration file {config_file}: {e}")
@@ -1200,6 +1292,7 @@ def main(
             limit_simultaneous_requests=limit_async_requests,
             user_file_paths=file_paths_list,
             no_progress=no_progress,
+            delete_all=delete_all,
         )
     try:
         importer = UserImporter(folio_client, config)

--- a/src/folio_data_import/UserImport.py
+++ b/src/folio_data_import/UserImport.py
@@ -45,6 +45,7 @@ PREFERRED_CONTACT_TYPES_MAP = {
 
 
 USER_MATCH_KEYS = ["username", "barcode", "externalSystemId"]
+PROTECTED_USER_TYPES = ["staff", "system", "shadow", "dcb"]
 
 
 class UserImporterStats(BaseModel):
@@ -792,7 +793,7 @@ class UserImporter:  # noqa: R0902
         Returns:
             None
         """
-        if existing_user.get("type", "") in ["staff", "system", "shadow", "dcb"]:
+        if existing_user.get("type", "") in PROTECTED_USER_TYPES:
             logger.warning(
                 f"Row {line_number}: User {existing_user['id']} "
                 f"is of type {existing_user.get('type', '')}, "
@@ -1075,9 +1076,10 @@ class UserImporter:  # noqa: R0902
                             )
                             message = (
                                 f"{dt.now().isoformat(sep=' ', timespec='milliseconds')}: "
-                                f"Batch of {self.config.batch_size} users processed in {duration:.2f} "
-                                f"seconds. - Users created: {self.stats.created} - Users updated: "
-                                f"{self.stats.updated} - Users failed: {self.stats.failed}"
+                                f"Batch of {self.config.batch_size} users processed in "
+                                f"{duration:.2f} seconds. - Users created: {self.stats.created}"
+                                f" - Users updated: {self.stats.updated} - Users failed: "
+                                f"{self.stats.failed}"
                             )
                         logger.info(message)
                     tasks = []
@@ -1305,7 +1307,7 @@ def main(
             with open(config_file, "r") as f:
                 config_data = json.load(f)
                 # CLI flags override config file values
-                config_data["delete_all"] = delete_all or config_data.get("delete_all", False)
+                config_data["delete_all"] = delete_all
                 config = UserImporter.Config(**config_data)
         except Exception as e:
             logger.critical(f"Failed to load configuration file {config_file}: {e}")

--- a/src/folio_data_import/_progress.py
+++ b/src/folio_data_import/_progress.py
@@ -267,6 +267,7 @@ class GenericStatsColumn(ProgressColumn):
         ("posted", "Posted", "bright_green"),
         ("created", "Created", "green"),
         ("updated", "Updated", "cyan"),
+        ("deleted", "Deleted", "yellow"),
         ("failed", "Failed", "red"),
         ("processed", "Processed", "blue"),
     ]


### PR DESCRIPTION
Enhance user record management by changing the update behavior to full replacement by default and introducing a new option to delete existing records instead of updating them. Update documentation to reflect these changes and add confirmation prompts for destructive operations. Bump version to 0.6.0.